### PR TITLE
Reintroduce SMHI Radiation Data Service

### DIFF
--- a/.github/workflows/smhi-api-weather-raw-deploy.yml
+++ b/.github/workflows/smhi-api-weather-raw-deploy.yml
@@ -1,0 +1,47 @@
+name: Deploy smhi-api-weather-raw
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'pipes/smhi-api-weather-raw/**'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+    - name: Set up Google Cloud SDK
+      uses: google-github-actions/setup-gcloud@v2
+      with:
+        project_id: ${{ secrets.GCP_PROJECT_ID }}
+        install_components: 'beta'
+
+    - name: Configure Docker
+      run: gcloud auth configure-docker
+
+    - name: Build Docker image
+      run: docker build -t gcr.io/${{ secrets.GCP_PROJECT_ID }}/smhi-api-weather-raw ./pipes/smhi-api-weather-raw
+
+    - name: Push Docker image
+      run: docker push gcr.io/${{ secrets.GCP_PROJECT_ID }}/smhi-api-weather-raw
+
+    - name: Deploy to Cloud Run
+      run: |
+        gcloud run deploy smhi-api-weather-raw-service \
+          --image gcr.io/${{ secrets.GCP_PROJECT_ID }}/smhi-api-weather-raw \
+          --platform managed \
+          --region europe-north1 \
+          --concurrency 2 \
+          --max-instances 2 \
+          --allow-unauthenticated \
+          --set-env-vars API_URL=${{ secrets.SMHI_API_URL }}

--- a/.github/workflows/smhi-api-weather-raw-workflow-deploy.yml
+++ b/.github/workflows/smhi-api-weather-raw-workflow-deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy smhi-api-weather-raw-workflow.yml
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'pipelines/smhi-api-weather-raw-workflow.yml'
+
+jobs:
+  deploy-workflow:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+    - name: Set up Google Cloud SDK
+      uses: google-github-actions/setup-gcloud@v2
+      with:
+        project_id: ${{ secrets.GCP_PROJECT_ID }}
+        install_components: 'beta'
+
+    - name: Deploy Google Workflow
+      run: |
+        gcloud workflows deploy radiation-ingestion-workflow \
+          --source pipelines/smhi-api-weather-raw-workflow.yml \
+          --location europe-north1

--- a/pipelines/smhi-api-weather-raw-workflow.yml
+++ b/pipelines/smhi-api-weather-raw-workflow.yml
@@ -1,0 +1,18 @@
+main:
+  params: []
+  steps:
+    - collectRadiationData:
+        call: http.get
+        args:
+          url: https://smhi-api-weather-raw-service-5d5xhd46ea-lz.a.run.app
+        result: PipelineResponse
+    - validatePipelineResponse:
+        switch:
+          - condition: ${PipelineResponse.body.status_code == 200}
+            steps:
+              - workflow_end:
+                  return: 'Workflow executed successfully'
+          - condition: ${PipelineResponse.body.status_code != 200}
+            steps:
+              - handleError:
+                  raise: '${"Error in workflow execution: " + PipelineResponse.content.message}'


### PR DESCRIPTION
This PR restores the SMHI radiation data service and adds its deployment and workflow configurations. Key changes include:

- **SMHI Service**: Fetches radiation data from the SMHI API.
- **Deployment Workflow**: GitHub Actions for deploying to Google Cloud Run.
- **Google Cloud Workflow**: Automates data collection.
- **Updated README**: Reflects the service in the architecture overview.

This ensures the SMHI service is fully operational within the data pipeline.
